### PR TITLE
Add resume download button with social icons

### DIFF
--- a/src/components/social.js
+++ b/src/components/social.js
@@ -41,6 +41,16 @@ const StyledSocialList = styled.ul`
       }
     }
   }
+
+  li.resume {
+    margin-top: 20px;
+
+    a {
+      ${({ theme }) => theme.mixins.smallButton};
+      font-size: var(--fz-xxs);
+      padding: 0.5rem 0.75rem;
+    }
+  }
 `;
 
 const Social = ({ isHome }) => (
@@ -54,6 +64,11 @@ const Social = ({ isHome }) => (
             </a>
           </li>
         ))}
+      <li className="resume">
+        <a href="/resume.pdf" download>
+          Resume
+        </a>
+      </li>
     </StyledSocialList>
   </Side>
 );


### PR DESCRIPTION
## Summary
- add resume download button next to the social icons
- style the button to match existing layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run format` *(fails: Cannot find module '@upstatement/prettier-config')*
- `npm run lint-staged` *(fails: lint-staged not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b9dad0748325979d538da84c48fa